### PR TITLE
Fixed token expiration issue

### DIFF
--- a/DSL/CronManager/DSL/data_resync.yml
+++ b/DSL/CronManager/DSL/data_resync.yml
@@ -1,5 +1,5 @@
 agency_data_resync:
-  # trigger: "0 0/1 * * * ?"
-  trigger: off
+  trigger: "0 0 0/1 * * ?"
+  # trigger: off
   type: exec
   command: "../app/scripts/agency_data_resync.sh -s 10"

--- a/vault-init.sh
+++ b/vault-init.sh
@@ -130,7 +130,7 @@ path "auth/token/lookup-self" { capabilities = ["read"] }'
     
     # Create LLM Orchestration AppRole
     echo "Creating llm-orchestration-service AppRole..."
-    wget -q -O- --post-data='{"token_policies":["llm-orchestration-policy"],"token_no_default_policy":true,"token_ttl":"1h","token_max_ttl":"24h","secret_id_ttl":"24h","secret_id_num_uses":0,"bind_secret_id":true}' \
+    wget -q -O- --post-data='{"token_policies":["llm-orchestration-policy"],"token_no_default_policy":true,"token_ttl":"1h","token_max_ttl":"8h","secret_id_ttl":"24h","secret_id_num_uses":0,"bind_secret_id":true}' \
         --header="X-Vault-Token: $ROOT_TOKEN" \
         --header='Content-Type: application/json' \
         "$VAULT_ADDR/v1/auth/approle/role/llm-orchestration-service" >/dev/null


### PR DESCRIPTION
This pull request introduces two changes: it updates the cron job schedule for agency data resync and reduces the maximum TTL for the LLM Orchestration AppRole tokens in Vault. These changes help ensure data resync jobs run at the correct intervals and tighten security for token usage.

**Scheduling and job management:**
* Updated the `agency_data_resync` cron job in `DSL/data_resync.yml` to run every hour instead of being turned off, by setting the trigger to `"0 0 0/1 * * ?"`.

**Security and token management:**
* Reduced the `token_max_ttl` for the LLM Orchestration AppRole from 24 hours to 8 hours in `vault-init.sh` to enhance security by limiting the maximum token lifetime.